### PR TITLE
root: add local development steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 # Intellij
 *.iml
 .idea
+settings.json
 
 # npm
 node_modules
 package-lock.json
 
 # build
+build
 main.js
 *.js.map
 
@@ -15,3 +17,4 @@ data.json
 
 # mac
 .DS_store
+

--- a/README.md
+++ b/README.md
@@ -225,3 +225,24 @@ Also you can register individual commands via [settings](#registered-invocable-s
 Do you find CustomJS useful? Consider buying me a coffee to fuel updates and more useful software like this. Thank you!
 
 <a href="https://www.buymeacoffee.com/samlewis" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
+
+## Local development
+
+1. Clone this repository into `<vaultpath>/.obsidian/plugins`
+
+Note: it is recommended to use a test vault when developing plugins.
+
+2. (if you are using node version manager, use the version from package.json -> devDependencies -> @types/node)
+
+3. Install dependencies: `npm install`
+
+4. Build in dev mode with `npm run dev`
+
+NOTE: if you place your repository somewhere else than in `plugins`, you can customize the output path with
+
+`OUTPUT_DIR=<vaultpath>/.obsidian/plugins/obsidian-custom-js npm run dev`
+
+See also:
+
+- Obsidian development guide: https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin
+- Hot reloading plugin: https://docs.obsidian.md/Plugins/Getting+started/Development+workflow

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ if you want to view the source visit the plugins github repository
 const cfg = {
   input: 'main.ts',
   output: {
-    dir: isProd ? 'build' : '/Users/samlewis/Obsidian/Personal Notes/.obsidian/plugins/customjs/',
+    dir: isProd ? 'build' : './',
     sourcemap: 'inline',
     sourcemapExcludeSources: isProd,
     format: 'cjs',
@@ -37,12 +37,28 @@ const cfg = {
 };
 
 if (!isProd) {
-  cfg.plugins.push(copy({
-    targets: [
-      { src: 'manifest.json', dest: '/Users/samlewis/Obsidian/Personal Notes/.obsidian/plugins/customjs/' },
-      { src: 'styles.css', dest: '/Users/samlewis/Obsidian/Personal Notes/.obsidian/plugins/customjs/' },
-    ]
-  }))
+  // Build by default to root of the plugin, but allow overriding if needed
+  // run with overrides with  OUTPUT_DIR='<path>' npm run dev
+  const devBuildPath = process.env.OUTPUT_DIR;
+
+  if(devBuildPath){
+    cfg.plugins.push(
+      copy({
+        targets: [
+          { src: 'manifest.json', dest: devBuildPath },
+          {
+            src: 'styles.css',
+            dest: devBuildPath,
+          },
+          {
+            src: 'main.js',
+            dest: devBuildPath,
+          },
+        ],
+      })
+    );
+  }
+  
 }
 
 export default cfg;


### PR DESCRIPTION
Hi! just a small pr that makes it easier to run locally / start contributing. 

**what**
- removes saml-dev local paths 
- adds support for overriding plugin build path (support for the removed saml-dev paths)

@saml-dev I'd be intested in contributing to development, but I would appreciate some sort of prettier config / linter to avoid conflicts with IDE settings. Would you be open to that? I'll gladly set it up if you are (and add CI check / formatting on commit). 