### PR TITLE
Add app to customJS object (global app is deprecated)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -130,7 +130,8 @@ export default class CustomJS extends Plugin {
   async loadClasses() {
     window.customJS = { 
       obsidian,
-      state: window.customJS?.state ?? {}
+      state: window.customJS?.state ?? {},
+      app: this.app
     };
     const filesToLoad = [];
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -6,6 +6,7 @@ declare global {
     forceLoadCustomJS?: () => Promise<void>;
     customJS?: {
       obsidian?: typeof obsidian,
+      app?: obsidian.App,
       state?: {}
       [scriptName: string]: unknown
     }


### PR DESCRIPTION
Add the plugin app reference to window.customJS, as the global app reference has been deprecated.