### PR TITLE
Improve synchronous script initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ class CoolString {
 
 // dataviewjs block in *.md
 ```dataviewjs
-const {CoolString} = customJS
+const {CoolString} = await cJS()
 dv.list(dv.pages().file.name.map(n => CoolString.coolify(n)))
 ```
 
 // templater template
 <%*
-const {CoolString} = customJS;
+const {CoolString} = await cJS();
 tR += CoolString.coolify(tp.file.title);
 %>
 ````
@@ -75,18 +75,18 @@ You can pass anything as parameters to your functions to allow for some incredib
 
 ````
 ```dataviewjs
-const {DvTasks} = customJS
+const {DvTasks} = await cJS()
 DvTasks.getOverdueTasks({app, dv, luxon, that:this, date:'2021-08-25'})
 ```
 
 ```dataviewjs
-const {DvTasks} = customJS
+const {DvTasks} = await cJS()
 DvTasks.getTasksNoDueDate({app, dv, luxon, that:this})
 ```
 
 ### Today's Tasks
 ```dataviewjs
-const {DvTasks} = customJS
+const {DvTasks} = await cJS()
 DvTasks.getTodayTasks({app, dv, luxon, that:this, date:'2021-08-25'})
 ```
 ### Daily Journal
@@ -204,10 +204,10 @@ CustomJS loads your modules at Obsidian's startup by hooking an event that says 
 
 > `customJS` is not defined
 
-If you see issues where the `customJS` variable is not defined, this is when you want to force it to load before your script continues. In order to allow this, we provide the asynchronous function `forceLoadCustomJS()`, also defined globally. This means that you can `await` it, thereby ensuring that `customJS` will be available when you need it.
+If you see issues where the `customJS` variable is not defined, this is when you want to force it to load before your script continues. In order to allow this, we provide the asynchronous function `cJS()`, also defined globally. This means that you can `await` it, thereby ensuring that `customJS` will be available when you need it.
 
 ```js
-await forceLoadCustomJS();
+await cJS();
 ```
 
 That said, most of the time **_you do not need to do this_**. In the vast majority of JavaScript execution taking place within Obsidian, customJS will be loaded.

--- a/README.md
+++ b/README.md
@@ -258,13 +258,25 @@ customJS.MyModule.doSomething()
 ```
 ````
 
+Wait for the plugin to fully load:
+````
+```js-engine
+while (!customJS?.state?._ready) {
+  await new Promise(resolve => setTimeout(resolve, 50))
+}
+
+// Arriving here means, all customJS properties are ready to be used
+customJS.MyModule.doSomething()
+```
+````
+
 #### The `cJS()` function
 
 CustomJS provides several ways on how to use the `cJS()` function:
 
 1. `async cJS(): customJS` .. The default return value is the [global object](#global-object).
 2. `async cJS( moduleName: string ): object` .. Using a string parameter will return a single property of the global object.
-3. `async cJS( Function ): customJS` .. Using a callback function will pass the global object as only parameter to that function.
+3. `async cJS( async Function ): customJS` .. Using a callback function will pass the global object as only parameter to that function.
 
 **Samples**
 
@@ -291,6 +303,19 @@ await cJS( customJS => customJS.MyModule.doSomething(dv) )
 
 // Or
 await cJS( ({MyModule}) => MyModule.doSomething(dv) )
+```
+````
+
+Run a custom async-callback when the customJS object is ready:
+````
+```js-engine
+async function runAsync(customJS) {
+    await customJS.MyModule.doSomethingAsync(engine)
+}
+await cJS(runAsync)
+
+// Or, as one-liner:
+await cJS( async (customJS) => {await customJS.MyModule.doSomethingAsync(engine)} )
 ```
 ````
 

--- a/main.ts
+++ b/main.ts
@@ -61,7 +61,7 @@ export default class CustomJS extends Plugin {
         if ('string' === typeof moduleOrCallback) {
           return window.customJS[moduleOrCallback];
         } else if ('function' === typeof moduleOrCallback) {
-          moduleOrCallback(window.customJS);
+          await moduleOrCallback(window.customJS);
         }
       }
 

--- a/main.ts
+++ b/main.ts
@@ -52,16 +52,20 @@ export default class CustomJS extends Plugin {
       await this.initCustomJS();
     };
 
-    window.cJS = async (requireModule?: string) => {
+    window.cJS = async (moduleOrCallback?: string|Function) => {
       if (!window.customJS?.state?._ready) {
         await this.initCustomJS();
       }
       
-      if (requireModule) {
-        return window.customJS[requireModule];
-      } else {
-        return window.customJS;
+      if (moduleOrCallback) {
+        if ('string' === typeof moduleOrCallback) {
+          return window.customJS[moduleOrCallback];
+        } else if ('function' === typeof moduleOrCallback) {
+          moduleOrCallback(window.customJS);
+        }
       }
+
+      return window.customJS;
     };
 
     this.app.workspace.onLayoutReady(async () => {

--- a/main.ts
+++ b/main.ts
@@ -40,7 +40,7 @@ export default class CustomJS extends Plugin {
   settings: CustomJSSettings;
   deconstructorsOfLoadedFiles: { deconstructor: () => void; name: string }[] =
     [];
-  loaderPromise = null;
+  loaderPromise: Promise<void>|null = null;
 
   async onload() {
     // eslint-disable-next-line no-console
@@ -52,8 +52,10 @@ export default class CustomJS extends Plugin {
       await this.initCustomJS();
     };
 
-    window.cJS = async (requireModule) => {
-      await this.initCustomJS();
+    window.cJS = async (requireModule?: string) => {
+      if (!window.customJS?.state?._ready) {
+        await this.initCustomJS();
+      }
       
       if (requireModule) {
         return window.customJS[requireModule];

--- a/main.ts
+++ b/main.ts
@@ -47,7 +47,7 @@ export default class CustomJS extends Plugin {
     console.log('Loading CustomJS');
     await this.loadSettings();
     this.registerEvent(this.app.vault.on('modify', this.reloadIfNeeded, this));
- 
+
     window.forceLoadCustomJS = async () => {
       await this.initCustomJS();
     };

--- a/types.d.ts
+++ b/types.d.ts
@@ -4,7 +4,7 @@ import { DataviewAPI } from 'obsidian-dataview';
 declare global {
   interface Window {
     forceLoadCustomJS?: () => Promise<void>;
-    cJS?: (requireModule?: string) => Promise<any>;
+    cJS?: (moduleOrCallback?: string|Function) => Promise<any>;
     customJS?: {
       obsidian?: typeof obsidian;
       app?: obsidian.App;

--- a/types.d.ts
+++ b/types.d.ts
@@ -4,6 +4,7 @@ import { DataviewAPI } from 'obsidian-dataview';
 declare global {
   interface Window {
     forceLoadCustomJS?: () => Promise<void>;
+    cJS?: (requireModule?: string) => Promise<any>;
     customJS?: {
       obsidian?: typeof obsidian;
       app?: obsidian.App;


### PR DESCRIPTION
PR for the logic suggested in Issue #85

**Changes:**

- `await forceLoadCustomJS()` does not start multiple concurrent loading operations; calling the function multiple times will load all classes once only.
- New API method `await cJS()` which acts as a shorthand accessor for the fully initialized `customJS` object. The method has three signatures:
  - `async cJS(): customJS`
  - `async cJS(moduleName: string): object`
  - `async cJS( Function ): customJS`
- This PR also introduces the new flag `customJS.state._ready` which is used internally but can also provide a public interface to evaluate the plugin's loading status

**Usage samples:**

1. Check the flag `state._ready`
````
```dataviewjs
if (!customJS.state?._ready) {
    await forceLoadCustomJS()
}
customJS.MyModule.doSomething()
```
````

2. Access the fully initialized `customJS` object
````
```dataviewjs
const modules = await cJS()
modules.MyModule.doSomething()
```
````

3. Access a single module from the `customJS` object
````
```dataviewjs
const MyModule = await cJS('MyModule')
MyModule.doSomething()
```
````

4. Run custom code via callback
````
```dataviewjs
await cJS( customJS => customJS.MyModule.doSomething() )
```
````